### PR TITLE
Bump Interact.js dep to fix JS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "touch"
   ],
   "dependencies": {
-    "interact.js": "1.2.6"
+    "interact.js": "1.2.8"
   },
   "peerDependencies": {
     "hyperdom": "0.2.0"


### PR DESCRIPTION
Interact.js 1.2.8 has been released which fixes:

![screencast](http://g.recordit.co/EaXXL6Eg68.gif)

Ref: https://github.com/taye/interact.js/issues/251